### PR TITLE
feat: PasswordResetModal 생성

### DIFF
--- a/src/components/PasswordResetModal.tsx
+++ b/src/components/PasswordResetModal.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Typography,
+  TextField,
+  Button,
+  IconButton,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+
+interface PasswordResetModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * @description 비밀번호 재설정 팝업(모달) 컴포넌트입니다.
+ * @param {object} props - React 컴포넌트 props
+ * @param {boolean} props.open - 모달의 열림/닫힘 상태
+ * @param {() => void} props.onClose - 모달을 닫을 때 호출되는 함수
+ * @returns {React.ReactElement} PasswordResetModal 컴포넌트
+ */
+const PasswordResetModal = ({ open, onClose }: PasswordResetModalProps) => {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ m: 0, p: 2, fontWeight: 'bold' }}>
+        비밀번호 재설정
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          sx={{
+            position: 'absolute',
+            right: 8,
+            top: 8,
+            color: (theme) => theme.palette.grey[500],
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers>
+        <Typography gutterBottom>
+          로그인 시 사용하는 이메일 또는 전화번호를 입력해주세요. 입력하신 이메일 또는 휴대전화로 비밀번호 재설정 링크가 전송됩니다.
+        </Typography>
+        <TextField
+          autoFocus
+          margin="dense"
+          id="emailOrPhone"
+          label="이메일 / 휴대전화"
+          type="text"
+          fullWidth
+          variant="outlined"
+          sx={{ mt: 2 }}
+        />
+      </DialogContent>
+      <DialogActions sx={{ p: '16px 24px' }}>
+        <Button onClick={onClose} variant="contained" fullWidth>
+          비밀번호 재설정 메시지 전송
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default PasswordResetModal;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
     Box,
     Typography,
@@ -8,14 +8,28 @@ import {
     Stack,
     IconButton,
 } from '@mui/material';
+import PasswordResetModal from '../components/PasswordResetModal';
 
 /**
  * @description 로그인 페이지 컴포넌트
  * @returns {React.ReactElement} LoginPage 컴포넌트
  */
 const LoginPage = () => {
+    // 모달의 열림/닫힘 상태를 관리하기 위한 state
+    const [isModalOpen, setModalOpen] = useState(false);
+
+    // 모달을 여는 함수
+    const handleOpenModal = () => {
+        setModalOpen(true);
+    };
+
+    // 모달을 닫는 함수
+    const handleCloseModal = () => {
+        setModalOpen(false);
+    };
+
     return (
-        // 전체 화면을 차지하고, 로그인 폼을 중앙에 배치하기 위한 Box 컨테이너
+        <>
         <Box
             sx={{
                 display: 'flex',
@@ -109,10 +123,14 @@ const LoginPage = () => {
                 { /* 회원가입 및 비밀번호 재설정 버튼 영역 */}
                 <Stack direction="column" spacing={2} justifyContent="center" sx={{ mt: 3 }}>
                     <Button variant="outlined" sx={{ flex: 1 }}>회원가입</Button>
-                    <Button variant="outlined" sx={{ flex: 1 }}>비밀번호 재설정</Button>
+                    <Button variant="outlined" sx={{ flex: 1 }} onClick={handleOpenModal}>비밀번호 재설정</Button>
                 </Stack>
             </Box>
         </Box>
+
+        {/* 모달 컴포넌트를 렌더링 */}
+        <PasswordResetModal open={isModalOpen} onClose={handleCloseModal} />
+        </>
     );
 };
 


### PR DESCRIPTION
## 🚀 구현 내용

- **`PasswordResetModal.tsx`** 컴포넌트를 `src/components/` 폴더에 새로 생성했습니다.
- MUI의 **`Dialog`** 컴포넌트를 사용하여, 기획에 맞는 비밀번호 재설정 팝업창 UI를 구현했습니다.
- **`LoginPage.tsx`**에 `useState` 훅을 사용하여 모달의 열림/닫힘 상태(`isModalOpen`)를 관리하는 로직을 추가했습니다.
- '비밀번호 재설정' 버튼에 `onClick` 이벤트를 연결하여, 버튼 클릭 시 모달이 정상적으로 나타나도록 구현했습니다.

---

## ✅ 테스트

- [x] `LoginPage`에서 '비밀번호 재설정' 버튼을 클릭하면 모달이 정상적으로 열리는지 확인했습니다.
- [x] 모달의 '나가기(X)' 버튼을 클릭하면 모달이 정상적으로 닫히는지 확인했습니다.

---

## 📌 참고 사항

- 현재 구현된 내용은 UI 및 상태 관리 로직이며, 실제 비밀번호 재설정 메시지를 전송하는 API 연동 기능은 포함되어 있지 않습니다.
- '비밀번호 재설정 메시지 전송' 버튼의 `onClick` 이벤트 핸들러는 다음 작업에서 구현할 예정입니다.
