### PR TITLE
feat: AgentPage에 AI 생성 예시 영역 추가

### DIFF
--- a/src/pages/AgentPage.tsx
+++ b/src/pages/AgentPage.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Box, Typography, TextField, IconButton } from '@mui/material';
+import { Box, Typography, TextField, IconButton, Paper } from '@mui/material';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 
-const examplePlaceholder = `(예시)
-안녕하세요. 마케팅리즈입니다.
+// 사용자가 입력한 내용을 보여주기 위한 예시 데이터
+const userInputExample = `안녕하세요. 마케팅리즈입니다.
 지난번 공지드린 마케팅 특강이 이번주에 시작합니다.
 
 - 일시: 25.11.11(화) 18시
@@ -11,9 +12,30 @@ const examplePlaceholder = `(예시)
 
 참석을 원하시면 미리 답장을 주세요.
 궁금하신 점이 있으시면 02-6402-0508로 연락주세요.
-
 감사합니다.`;
 
+// AI 생성 예시로 보여줄 데이터
+const aiGenerationExample = {
+  title: '행사 정보 안내드립니다!',
+  content: `안녕하세요. 고객님 마케팅리즈입니다.
+마케팅 특강 스터디 모임 일정이 확정되었습니다.
+
+다음은 모임에 대한 상세 정보입니다.
+
+▶ 모임명 : 마케팅 특강
+▶ 일시 : 2025년 11월 11일(화) 오후 6시
+▶ 장소 : 서울 마포구 양화로 186 6층
+▶ 문의사항 : 02-6402-0508
+
+참석을 원하시면 미리 답장을 주시기바랍니다.
+
+감사합니다.`,
+};
+
+/**
+ * @description AI 에이전트에게 사용자가 첫 요청을 보내는 페이지 컴포넌트입니다.
+ * @returns {React.ReactElement} AgentPage 컴포넌트
+ */
 const AgentPage = () => {
   return (
     <Box
@@ -21,52 +43,99 @@ const AgentPage = () => {
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        gap: 2,
+        gap: 4,
         p: 4,
       }}
     >
-      <Typography variant="h4" component="h1" gutterBottom sx={{ fontWeight: 'bold' }}>
-        카카오 알림톡으로 발송할 메시지 내용을 입력하세요
-      </Typography>
+      {/* 1. 상단 타이틀 및 입력창 영역 */}
+      <Box sx={{ width: '100%', maxWidth: '800px', textAlign: 'center' }}>
+        <Typography variant="h4" component="h1" gutterBottom sx={{ fontWeight: 'bold' }}>
+          카카오 알림톡으로
+          <br />
+          발송할 메시지 내용을 입력하세요
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
+          문자 메시지를 보낸다고 생각하시고 메시지를 입력해주세요
+        </Typography>
+        <Box sx={{ position: 'relative' }}>
+          <TextField
+            multiline
+            rows={12}
+            placeholder={userInputExample}
+            variant="outlined"
+            fullWidth
+            sx={{
+              backgroundColor: 'white',
+            }}
+          />
+          <IconButton
+            sx={{
+              position: 'absolute',
+              right: 16,
+              bottom: 16,
+              backgroundColor: 'primary.main',
+              color: 'white',
+              '&:hover': {
+                backgroundColor: 'primary.dark',
+              },
+            }}
+          >
+            <ArrowUpwardIcon />
+          </IconButton>
+        </Box>
+      </Box>
 
-      <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
-        문자 메시지를 보낸다고 생각하시고 메시지를 입력해주세요
-      </Typography>
-
-      {/* 1. TextField와 IconButton을 감싸는 Box 컨테이너를 만듭니다. */}
-      <Box
-        sx={{
-          position: 'relative', // 자식 요소의 위치 기준점이 됩니다.
-          width: '100%',
-          maxWidth: '700px',
-        }}
-      >
-        <TextField
-          multiline
-          rows={10}
-          placeholder={examplePlaceholder}
-          variant="outlined"
-          sx={{
-            width: '100%',
-            backgroundColor: 'white',
-          }}
-        />
+      {/* 2. 하단 예시 비교 영역 */}
+      {/* [수정] 전체 너비를 위쪽 TextField와 맞추기 위해 maxWidth를 800px로 설정합니다. */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, width: '100%', maxWidth: '800px', mt: 4 }}>
         
-        {/* 2. 텍스트 상자 내부에 위치할 아이콘 버튼입니다. */}
-        <IconButton
-          sx={{
-            position: 'absolute', // 부모(Box)를 기준으로 위치를 절대적으로 지정합니다.
-            right: 16, // 오른쪽에서 16px 떨어짐
-            bottom: 16, // 아래쪽에서 16px 떨어짐
-            backgroundColor: 'primary.main', // 버튼 배경색
-            color: 'white', // 아이콘 색상
-            '&:hover': {
-              backgroundColor: 'primary.dark', // 마우스 올렸을 때 배경색
-            },
-          }}
-        >
-          <ArrowUpwardIcon />
-        </IconButton>
+        {/* 왼쪽: 입력한 내용 영역 */}
+        <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          {/* [수정] 제목을 Paper 바깥으로 뺐습니다. */}
+          <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mb: 1.5, textAlign: 'center' }}>
+            입력한 내용
+          </Typography>
+          <Paper
+            variant="outlined"
+            sx={{
+              p: 3,
+              borderColor: '#e0e0e0',
+              height: '40vh',
+              overflowY: 'auto',
+            }}
+          >
+            <Typography sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.7, color: 'text.secondary' }}>
+              {userInputExample}
+            </Typography>
+          </Paper>
+        </Box>
+
+        {/* 가운데 화살표 */}
+        <ArrowForwardIcon sx={{ fontSize: 40, color: 'grey.500', alignSelf: 'center', mt: 4 }} />
+
+        {/* 오른쪽: AI 생성 예시 영역 */}
+        <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          {/* [수정] 제목을 Paper 바깥으로 뺐습니다. */}
+          <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mb: 1.5, textAlign: 'center' }}>
+            AI 생성 예시
+          </Typography>
+          <Paper
+            sx={{
+              p: 3,
+              backgroundColor: '#fef01b',
+              borderRadius: '12px',
+              height: '40vh',
+              overflowY: 'auto',
+            }}
+          >
+            <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 2 }}>
+              {aiGenerationExample.title}
+            </Typography>
+            <Typography sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}>
+              {aiGenerationExample.content}
+            </Typography>
+          </Paper>
+        </Box>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## 🚀 구현 내용

- 입력창 하단에 사용자의 입력과 AI의 생성 결과를 비교해서 보여주는 **2단 구조의 예시 영역**을 추가했습니다.
- 가독성 향상을 위해 메인 타이틀에 **줄바꿈(`<br />`)**을 적용하고, 컴포넌트 간 **여백(margin)을 조정**하여 전체적인 UI를 다듬었습니다.

---

## ✅ 테스트

- [x] 페이지가 디자인 시안에 맞게 정상적으로 렌더링되는지 확인했습니다.
- [x] 텍스트 입력창 및 각종 UI 요소가 시각적으로 깨지지 않고 잘 보이는지 확인했습니다.

---

## 📌 참고 사항

- 현재 구현된 내용은 UI 뼈대이며, 실제 기능 로직은 포함되어 있지 않습니다.
- 텍스트 입력창의 상태 관리 및 전송 버튼의 `onClick` 이벤트 핸들러는 다음 작업에서 구현할 예정입니다.
