### PR TITLE
feat: MyTemplatesPage UI 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter, Routes, Route, Navigate, Outlet } from 'react-router-dom
 import LoginPage from './pages/LoginPage';
 import AgentPage from './pages/AgentPage';
 import SuggestionPage from './pages/SuggestionPage';
-import MyTemplatePage from './pages/MyTemplatePage';
+import MyTemplatesPage from './pages/MyTemplatesPage';
 import SignupPage from './pages/SignupPage';
 
 import Layout from './components/Layout';
@@ -40,7 +40,7 @@ export default function App() {
         <Route element={<ProtectedLayout isLoggedIn={isLoggedIn} />}>
           <Route path="/agent" element={<AgentPage />} />
           <Route path="/suggestion" element={<SuggestionPage />} />
-          <Route path="/my-templates" element={<MyTemplatePage />} />
+          <Route path="/my-templates" element={<MyTemplatesPage />} />
         </Route>
         
         {/* 그 외 모든 경로는 로그인 상태에 따라 리다이렉트 */}

--- a/src/pages/MyTemplatePage.tsx
+++ b/src/pages/MyTemplatePage.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const MyTemplatePage = () => {
-    return <div>내 템플릿 보관함 페이지</div>;
-};
-
-export default MyTemplatePage;

--- a/src/pages/MyTemplatesPage.tsx
+++ b/src/pages/MyTemplatesPage.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import {
+    Box,
+    Typography,
+    Button,
+    Paper,
+    Chip,
+    IconButton,
+} from '@mui/material';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
+
+/**
+ * 
+ * @description 저장된 모든 템플릿을 모아보는 보관함 페이지
+ * @returns {React.ReactElement} MyTemplatesPage 컴포넌트
+ */
+const MyTemplatePage = () => {
+    // 저장된 템플릿 목록. 후에 API와 연결함(임시 더미 데이터)
+    
+    const savedTemplates = [
+        { id: 1, title: '국가 검진 안내', type: '메시지형', content: '안녕하세요, #{고객명}님. #{발신 스페이스}입니다.올해 국가검진 대상자인 직원분들께 발송되는 메시지입니다...' },
+        { id: 2, title: '회사소개서 발송', type: '문서연결형', content: '요청하신 회사소개서를 보내드립니다! 확인 후 연락주세요...' },
+        { id: 3, title: '서비스 소개서 발송', type: '링크연결형', content: '요청하신 서비스 소개서가 발송되었습니다. 확인해주세요...' },
+        { id: 4, title: '회원가입 완료', type: '메시지형', content: '회원가입을 축하합니다! #{고객명}님의 가입이 정상적으로 완료되었습니다.' },
+        { id: 5, title: '쿠폰 발급 안내', type: '메시지형', content: '안녕하세요! #{고객명}님께만 드리는 특별 쿠폰이 발급되었습니다.' },
+        { id: 6, title: '주문 발송 안내', type: '링크연결형', content: '주문하신 상품이 발송되었습니다. 송장번호: #{송장번호}' },
+        { id: 7, title: '예약 확인 안내', type: '메시지형', content: '#{고객명}님, #{예약일시}에 예약이 확정되었습니다. 잊지 말고 방문해주세요.' },
+        { id: 8, title: '제품 브로슈어', type: '문서연결형', content: '신제품 브로슈어를 첨부하여 보내드립니다. 검토 후 피드백 부탁드립니다.' },
+        { id: 9, title: '설문조사 참여 요청', type: '링크연결형', content: '서비스 개선을 위한 설문조사에 참여해주세요. 참여하기: #{링크}' },
+        { id: 10, title: '비밀번호 재설정', type: '메시지형', content: '비밀번호 재설정을 위한 인증번호는 [#{인증번호}] 입니다.' },
+        { id: 11, title: '블로그 새 글 알림', type: '링크연결형', content: '새로운 글이 포스팅되었습니다! 지금 바로 확인해보세요. 제목: #{글제목}' },
+        { id: 12, title: '세금계산서 발행 안내', type: '문서연결형', content: '요청하신 세금계산서가 발행되었습니다. 국세청 홈택스에서 확인 가능합니다.' },
+        { id: 13, title: '추석 감사 인사', type: '메시지형', content: '풍요로운 한가위 보내세요. 저희 서비스를 이용해주셔서 항상 감사합니다.' },
+        { id: 14, title: '앱 다운로드 링크', type: '링크연결형', content: '더 편리한 서비스 이용을 위해 앱을 다운로드하세요! 다운로드: #{앱링크}' },
+    ];
+
+    // 타입에 따라 Chip의 색상을 결정하는 함수
+    const getTypeColor = (type: string) => {
+        if (type === '메시지형') return 'primary';
+        if (type === '문서연결형') return 'success';
+        if (type === '링크연결형') return 'warning';
+        return 'default';
+    }
+
+    return (
+        <Box>
+            { /* 페이지 상단 헤더 */}
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
+                <Typography variant="h4" component="h1" sx={{ fontWeight: 'bold' }}>
+                    내가 만든 템플릿
+                </Typography>
+                <Button variant="contained" size="large">
+                    새 템플릿 만들기
+                </Button>
+            </Box>
+
+            {/* 반응형 */}
+            <Box
+                sx={{
+                    display: 'grid',
+                    rowGap: 8,
+                    columnGap: 3,
+
+                    // 화면 크기에 따라 한 줄에 표시될 카드 개수를 조절
+                    gridTemplateColumns: {
+                        xs: 'repeat(1, 1fr)', // 가장 작은 화면: 1개
+                        sm: 'repeat(2, 1fr)', // 작은 화면: 2개
+                        md: 'repeat(2, 1fr)',
+                        lg: 'repeat(3, 1fr)', // 중간 화면: 3개
+                        xl: 'repeat(4, 1fr)', // 큰 화면: 4개
+                    },
+                }}
+            >
+                {savedTemplates.map((template) => (
+                    <Paper
+                        key={template.id}
+                        variant="outlined"
+                        sx={{
+                        p: 2.5,
+                        borderColor: '#e0e0e0',
+                        height: '100%',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        justifyContent: 'space-between',
+                        }}
+                    >
+                        {/* 카드 상단 헤더 */}
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1.5 }}>
+                            <Chip label={template.type} color={getTypeColor(template.type)} size="small" />
+                            <IconButton size="small">
+                                <StarBorderIcon fontSize="small" />
+                            </IconButton>
+                        </Box>
+
+                        {/* 카드 내부에 템플릿 미리보기 */}
+                        <Paper
+                            elevation={0}
+                            sx={{
+                                p: 2,
+                                backgroundColor: '#f5f5f5',
+                                borderRadius: '8px',
+                                flexGrow: 1,
+                                my: 2,
+                            }}
+                        >
+                            <Typography variant="body2" sx={{ fontWeight: 'bold', mb: 1 }}>
+                                {template.title}
+                            </Typography>
+                            <Typography variant="caption" color="text.secondary" sx={{
+                                display: '-webkit-box',
+                                WebkitLineClamp: 4,
+                                WebkitBoxOrient: 'vertical',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                            }}>
+                                {template.content}
+                            </Typography>
+                        </Paper>
+
+                    
+                       {/* 카드 하단 버튼 */}
+                        <Button fullWidth variant="text" sx={{ justifyContent: 'flex-start' }}>
+                            자세히 보기
+                        </Button>
+                    </Paper>
+                ))}
+            </Box>
+        </Box>
+    );
+};
+
+export default MyTemplatePage;


### PR DESCRIPTION
## 🚀 구현 내용

- **`MyTemplatesPage.tsx`** 페이지의 전체적인 UI를 구현했습니다.
- **'템플릿 유형'**(`type`)을 만들어, 각 유형에 맞는 색상의 `Chip`을 적용했습니다.
- **반응형 웹**을 고려하여, MUI의 `Box` 컴포넌트와 CSS Grid(`display: 'grid'`)를 사용해 화면 너비에 따라 카드 개수가 자동으로 조절되는 레이아웃을 구현했습니다. => Grid만 쓸 경우 오류생겨서 Box 컴포넌트와 CSS Grid 이용
- 카드 간 간격이 겹치는 문제를 해결하기 위해 `rowGap`과 `columnGap`을 명확하게 지정했습니다.

---

## ✅ 테스트

- [x] 다양한 화면 너비(xs, sm, md, lg, xl)에서 카드 레이아웃이 깨지지 않고 정상적으로 보이는지 수동으로 테스트를 완료했습니다.
- [x] 각 템플릿 유형에 맞는 `Chip` 색상이 올바르게 표시되는지 확인했습니다.

---

## 📌 참고 사항

- 현재 페이지에 표시되는 템플릿 목록은 UI 구현을 위한 임시 **더미 데이터**입니다. 추후 백엔드 API 연동을 통해 실제 사용자 데이터를 불러오는 로직으로 대체될 예정입니다.